### PR TITLE
Deadline API, tests and makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ebin/*
 .eunit/*
-.rebar3
+rebar3
+_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 ebin/*
+.eunit/*
+.rebar3

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,53 @@
+.PHONY: rel stagedevrel deps test
+
+all: deps compile
+
+compile:
+	rebar compile
+
+deps:
+	rebar get-deps
+
+clean:
+	rebar clean
+
+distclean: clean
+	rebar delete-deps
+
+test:
+	rebar get-deps compile
+	rebar eunit -v skip_deps=true
+
+##
+## Doc targets
+##
+docs:
+	rebar doc
+
+APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
+	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
+COMBO_PLT = $(HOME)/.riak_combo_dialyzer_plt
+
+check_plt: compile
+	dialyzer --check_plt --plt $(COMBO_PLT) --apps $(APPS)
+
+build_plt: compile
+	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS)
+
+dialyzer: compile
+	@echo
+	@echo Use "'make check_plt'" to check PLT prior to using this target.
+	@echo Use "'make build_plt'" to build PLT prior to using this target.
+	@echo
+	@sleep 1
+	dialyzer -Wno_return --plt $(COMBO_PLT) ebin | \
+		fgrep -v -f ./dialyzer.ignore-warnings
+
+cleanplt:
+	@echo 
+	@echo "Are you sure?  It takes about 1/2 hour to re-build."
+	@echo Deleting $(COMBO_PLT) in 5 seconds.
+	@echo 
+	sleep 5
+	rm $(COMBO_PLT)
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+GNUMAKE?= gmake
+
+all:
+	${GNUMAKE} $@
+
+.DEFAULT:
+	${GNUMAKE} $@
+
+.PHONY: all

--- a/README.md
+++ b/README.md
@@ -4,12 +4,36 @@ Buffalo
 An Erlang app for delayed process execution.
 
     buffalo:start().
-    buffalo:queue(Module, Function, Args, Delay).
+    buffalo:queue({Module, Function, Args}, #{ timeout => Delay }).
 
-Will call the MFA after `Delay` milliseconds. When calling queue/4
+Will call the MFA after `Delay` milliseconds. When calling queue/2
 with the same MFA arguments again without the first one being executed
 yet, the execution of the first one is cancelled and it will take
 again `Delay` ms. for the MFA to be called.
 
 For guaranteed execution, the MFA is called within a worker gen_server
 as part of the `buffalo_worker_sup` supervisor.
+
+Timeout
+-------
+
+The default timeout is 500 msec.
+
+Deadline
+--------
+
+The MFA is guaranteed to be executed at a defined deadline. The default
+deadline is 5 times the given timeout (defaults to 2500 msec).
+
+A specific deadline can be specified:
+
+    buffalo:queue({Module, Function, Args}, #{ timeout => 100, deadline => 250 }).
+
+Unique Key
+----------
+
+Normally the tasks are deduplicated by matching on the complete MFA. It is possible
+to supply an identifying key instead. This makes it possible to update the MFA associated
+with the key.
+
+    buffalo:queue(Key, MFA, #{ timeout => 50, deadline => 400 }).

--- a/ebin/buffalo.app
+++ b/ebin/buffalo.app
@@ -1,9 +1,0 @@
-{application,buffalo,
-             [{description,[]},
-              {vsn,"1"},
-              {registered,[]},
-              {applications,[kernel,stdlib]},
-              {mod,{buffalo_app,[]}},
-              {env,[]},
-              {modules,[buffalo,buffalo_app,buffalo_queuer,buffalo_sup,
-                        buffalo_worker,buffalo_worker_sup]}]}.

--- a/include/buffalo.hrl
+++ b/include/buffalo.hrl
@@ -1,0 +1,6 @@
+
+%% @doc How many times longer than the specified delay we will wait.
+-define(DEADLINE_MULTIPLIER, 5).
+
+%% @doc Record used for administrating which functions are queued.
+-record(buffalo_entry, {key, mfa, timer, deadline}).

--- a/include/buffalo.hrl
+++ b/include/buffalo.hrl
@@ -1,4 +1,7 @@
 
+%% @doc Default timeout - 500 msec
+-define(DEFAULT_TIMEOUT, 500).
+
 %% @doc How many times longer than the specified delay we will wait.
 -define(DEADLINE_MULTIPLIER, 5).
 

--- a/rebar.config
+++ b/rebar.config
@@ -11,3 +11,7 @@
 ]}.
 
 {eunit_opts, [verbose]}.
+
+{xref_checks, [undefined_function_calls,
+               locals_not_used,
+               deprecated_function_calls]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,13 @@
+{erl_opts, [
+    {parse_transform, lager_transform},
+    debug_info,
+    warn_unused_vars,
+    warn_shadow_vars,
+    warn_unused_import
+]}.
+
+{deps, [
+    {lager, "3.6.10"}
+]}.
+
+{eunit_opts, [verbose]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+{"1.1.0",
+[{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.6.10">>},0}]}.
+[
+{pkg_hash,[
+ {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"lager">>, <<"6172B43AB720AC33914CCD0AEB21FDBDF88213847707D4B91E6AF57B2AE5C4D2">>}]}
+].

--- a/src/buffalo.app.src
+++ b/src/buffalo.app.src
@@ -1,6 +1,6 @@
 {application, buffalo,
  [
-  {description, ""},
+  {description, "Buffalo - deduplicated erlang apply"},
   {vsn, "1"},
   {registered, []},
   {applications, [

--- a/src/buffalo.erl
+++ b/src/buffalo.erl
@@ -38,11 +38,11 @@
 start() ->
     application:start(buffalo).
 
--spec queue( mfa(), options() ) -> ok.
+-spec queue( mfa(), options() ) -> {ok, existing | new}.
 queue(MFA, Opts) ->
     buffalo_queuer:queue(MFA, Opts).
 
--spec queue( key(), mfa(), options() ) -> ok.
+-spec queue( key(), mfa(), options() ) -> {ok, existing | new}.
 queue(Key, MFA, Opts) ->
     buffalo_queuer:queue(Key, MFA, Opts).
 
@@ -54,12 +54,12 @@ cancel(Key) ->
 
 
 %% @doc Deprecated API
--spec queue( atom(), atom(), list(), pos_integer() ) -> ok.
+-spec queue( atom(), atom(), list(), pos_integer() ) -> {ok, existing | new}.
 queue(Module, Function, Arguments, Timeout) when is_integer(Timeout) ->
     buffalo_queuer:queue({Module, Function, Arguments}, #{ timeout => Timeout }).
 
 %% @doc Deprecated API
--spec queue( key(), atom(), atom(), list(), pos_integer() ) -> ok.
+-spec queue( key(), atom(), atom(), list(), pos_integer() ) -> {ok, existing | new}.
 queue(Key, Module, Function, Arguments, Timeout) when is_integer(Timeout) ->
     buffalo_queuer:queue(Key, {Module, Function, Arguments}, #{ timeout => Timeout }).
 

--- a/src/buffalo.erl
+++ b/src/buffalo.erl
@@ -20,8 +20,17 @@
 
 -export([
     start/0,
-    queue/2, queue/3, queue/4, queue/5,
-    cancel/1, cancel/3
+    queue/2, queue/3,
+    cancel/1
+]).
+
+-deprecated([{queue,4,eventually}]).
+-deprecated([{queue,5,eventually}]).
+-deprecated([{cancel,3,eventually}]).
+
+-export([
+    queue/4, queue/5,
+    cancel/3
 ]).
 
 -type options() :: #{

--- a/src/buffalo.erl
+++ b/src/buffalo.erl
@@ -1,3 +1,21 @@
+%% @author Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2012-2019 Arjan Scherpenisse
+%% @doc Buffalo main API
+
+%% Copyright 2012-2019 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(buffalo).
 -export([start/0, queue/4, queue/5, cancel/1, cancel/3]).
 

--- a/src/buffalo_app.erl
+++ b/src/buffalo_app.erl
@@ -1,3 +1,21 @@
+%% @author Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2012-2019 Arjan Scherpenisse
+%% @doc Buffalo application
+
+%% Copyright 2012-2019 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(buffalo_app).
 
 -behaviour(application).

--- a/src/buffalo_queuer.erl
+++ b/src/buffalo_queuer.erl
@@ -1,3 +1,21 @@
+%% @author Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2012-2019 Arjan Scherpenisse
+%% @doc Buffalo queuer: buffers, deduplicates, and starts workers
+
+%% Copyright 2012-2019 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(buffalo_queuer).
 -behaviour(gen_server).
 

--- a/src/buffalo_sup.erl
+++ b/src/buffalo_sup.erl
@@ -3,6 +3,8 @@
 
 -behaviour(supervisor).
 
+-include("../include/buffalo.hrl").
+
 %% API
 -export([start_link/0]).
 
@@ -24,7 +26,7 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-    ets:new(buffalo, [named_table, public]),
+    ets:new(buffalo, [set, named_table, public, {keypos, #buffalo_entry.key}]),
     Children = [?CHILD(buffalo_worker_sup, supervisor),
                 ?CHILD(buffalo_queuer, worker)],
     {ok, { {one_for_one, 5, 10}, Children} }.

--- a/src/buffalo_sup.erl
+++ b/src/buffalo_sup.erl
@@ -1,3 +1,20 @@
+%% @author Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2012-2019 Arjan Scherpenisse
+%% @doc Buffalo main supervisor
+
+%% Copyright 2012-2019 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module(buffalo_sup).
 

--- a/src/buffalo_worker.erl
+++ b/src/buffalo_worker.erl
@@ -1,3 +1,21 @@
+%% @author Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2012-2019 Arjan Scherpenisse
+%% @doc Buffalo worker, executes a buffered task
+
+%% Copyright 2012-2019 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(buffalo_worker).
 -behaviour(gen_server).
 

--- a/src/buffalo_worker.erl
+++ b/src/buffalo_worker.erl
@@ -35,7 +35,15 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info(timeout, {Module, Function, Args}) ->
-    ok = erlang:apply(Module, Function, Args),
+    case erlang:apply(Module, Function, Args) of
+        ok ->
+            ok;
+        {ok, _} -> 
+            ok;
+        Other ->
+            lager:warning("[buffalo] call to ~p:~p returned ~p. Args were: ~p", 
+                          [Module, Function, Other, Args])
+    end,
     {stop, normal, undefined};
 
 handle_info(_Info, State) ->

--- a/src/buffalo_worker_sup.erl
+++ b/src/buffalo_worker_sup.erl
@@ -1,3 +1,20 @@
+%% @author Arjan Scherpenisse <arjan@scherpenisse.net>
+%% @copyright 2012-2019 Arjan Scherpenisse
+%% @doc Buffalo supervisor for task workers
+
+%% Copyright 2012-2019 Arjan Scherpenisse
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module(buffalo_worker_sup).
 

--- a/test/buffalo_test.erl
+++ b/test/buffalo_test.erl
@@ -1,23 +1,32 @@
-%%%-------------------------------------------------------------------
-%%% @author Paul Peregud <paulperegud@gmail.com>
-%%% @copyright (C) 2013, Paul Peregud
-%%% @doc
-%%%
-%%% @end
-%%% Created : 25 Jun 2013 by Paul Peregud <paulperegud@gmail.com>
-%%% Modified : 30 Jan 2014 by Marc Worrell <marc@worrell.nl>
-%%%-------------------------------------------------------------------
+%% @author Paul Peregud <paulperegud@gmail.com>
+%% @copyright 2013-2019 Paul Peregud
+%% @doc Tests for buffalo
+
+%% Copyright 2013-2019 Paul Peregud
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(buffalo_test).
- 
+
 -include_lib("eunit/include/eunit.hrl").
- 
+
 %% API
 -export([
     send/2
     ]).
- 
+
 %% tests
- 
+
 all_test_() ->
     {foreach, fun () -> setup() end,
      fun (State) -> cleanup(State) end,
@@ -26,13 +35,13 @@ all_test_() ->
       , {timeout, 100, fun test_deadline/0}
       , {timeout, 100, fun test_cancel/0}
       ]}.
- 
+
 setup() ->
     application:start(buffalo).
- 
+
 cleanup(_) ->
     application:stop(buffalo).
- 
+
 test_timeout() ->
     Unit = 100,
     Msg = ping,
@@ -48,7 +57,7 @@ test_cancel() ->
     buffalo:cancel(cancel_test),
     ok = dont_receive(2*Unit),
     ok.
- 
+
 test_update() ->
     Unit = 100,
     Msg = ping,
@@ -58,7 +67,7 @@ test_update() ->
     ok = dont_receive(trunc(0.7*Unit)),
     Msg = do_receive(Msg, Unit),
     ok.
- 
+
 test_deadline() ->
     Unit = 100,
     Msg = ping,
@@ -82,7 +91,7 @@ test_deadline() ->
     Msg = do_receive(Msg, trunc(0.4*Unit)),
     % And the queue should be emptied.
     ok = dont_receive(trunc(1.2*Unit)).
- 
+
 dont_receive(T) ->
     receive
         Msg ->
@@ -90,7 +99,7 @@ dont_receive(T) ->
     after
         T -> ok
     end.
- 
+
 do_receive(What, After) ->
     receive
         What ->
@@ -98,7 +107,7 @@ do_receive(What, After) ->
     after After ->
             timeout
     end.
- 
+
 send(Pid, Msg) ->
     Pid ! Msg,
     ok.

--- a/test/buffalo_test.erl
+++ b/test/buffalo_test.erl
@@ -1,0 +1,105 @@
+%%%-------------------------------------------------------------------
+%%% @author Paul Peregud <paulperegud@gmail.com>
+%%% @copyright (C) 2013, Paul Peregud
+%%% @doc
+%%%
+%%% @end
+%%% Created : 25 Jun 2013 by Paul Peregud <paulperegud@gmail.com>
+%%% Modified : 30 Jan 2014 by Marc Worrell <marc@worrell.nl>
+%%%-------------------------------------------------------------------
+-module(buffalo_test).
+ 
+-include_lib("eunit/include/eunit.hrl").
+ 
+%% API
+-export([
+    send/2
+    ]).
+ 
+%% tests
+ 
+all_test_() ->
+    {foreach, fun () -> setup() end,
+     fun (State) -> cleanup(State) end,
+     [{timeout, 100, fun test_timeout/0}
+      , {timeout, 100, fun test_update/0}
+      , {timeout, 100, fun test_deadline/0}
+      , {timeout, 100, fun test_cancel/0}
+      ]}.
+ 
+setup() ->
+    application:start(buffalo).
+ 
+cleanup(_) ->
+    application:stop(buffalo).
+ 
+test_timeout() ->
+    Unit = 100,
+    Msg = ping,
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(Unit-10),
+    Msg = do_receive(Msg, Unit),
+    ok.
+
+test_cancel() ->
+    Unit = 100,
+    Msg = ping,
+    buffalo:queue(cancel_test, ?MODULE, send, [self(), Msg], Unit),
+    buffalo:cancel(cancel_test),
+    ok = dont_receive(2*Unit),
+    ok.
+ 
+test_update() ->
+    Unit = 100,
+    Msg = ping,
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    Msg = do_receive(Msg, Unit),
+    ok.
+ 
+test_deadline() ->
+    Unit = 100,
+    Msg = ping,
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.7*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    ok = dont_receive(trunc(0.5*Unit)),
+    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    % We are now at 4.7 x initial unit
+    % The deadline (at 5x) should trigger soon.
+    Msg = do_receive(Msg, trunc(0.4*Unit)),
+    % And the queue should be emptied.
+    ok = dont_receive(trunc(1.2*Unit)).
+ 
+dont_receive(T) ->
+    receive
+        Msg ->
+            {error, Msg}
+    after
+        T -> ok
+    end.
+ 
+do_receive(What, After) ->
+    receive
+        What ->
+            What
+    after After ->
+            timeout
+    end.
+ 
+send(Pid, Msg) ->
+    Pid ! Msg,
+    ok.
+

--- a/test/buffalo_test.erl
+++ b/test/buffalo_test.erl
@@ -45,7 +45,7 @@ cleanup(_) ->
 test_timeout() ->
     Unit = 100,
     Msg = ping,
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit}),
     ok = dont_receive(Unit-10),
     Msg = do_receive(Msg, Unit),
     ok.
@@ -53,7 +53,7 @@ test_timeout() ->
 test_cancel() ->
     Unit = 100,
     Msg = ping,
-    buffalo:queue(cancel_test, ?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue(cancel_test, {?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     buffalo:cancel(cancel_test),
     ok = dont_receive(2*Unit),
     ok.
@@ -61,9 +61,9 @@ test_cancel() ->
 test_update() ->
     Unit = 100,
     Msg = ping,
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
     Msg = do_receive(Msg, Unit),
     ok.
@@ -71,21 +71,21 @@ test_update() ->
 test_deadline() ->
     Unit = 100,
     Msg = ping,
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.7*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     ok = dont_receive(trunc(0.5*Unit)),
-    buffalo:queue(?MODULE, send, [self(), Msg], Unit),
+    buffalo:queue({?MODULE, send, [self(), Msg]}, #{ timeout => Unit }),
     % We are now at 4.7 x initial unit
     % The deadline (at 5x) should trigger soon.
     Msg = do_receive(Msg, trunc(0.4*Unit)),


### PR DESCRIPTION
This adds:

 * simpler API with `mfa()` parameters and options map
 * deadline (5x delay) so that execution is guaranteed within a certain period
 * tests
 * relaxed handling of MFA return values
 * Makefile and rebar.config
 * License information
